### PR TITLE
add symfony/yaml to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   ],
   "require": {
     "ext-curl": "*",
-    "monolog/monolog": "^1.20"
+    "monolog/monolog": "^1.20",
+    "symfony/yaml": "^4.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",


### PR DESCRIPTION
Because this dependency requires only in composer require-dev mode ( by phpunit), it should be required in production too